### PR TITLE
Add per instance info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ prime
 *.snap
 snap
 stage
+.cache
+.vscode
+*.egg-info

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -468,20 +468,19 @@ class Nova():
                     i['id'], i['name'], i['tenant_id'], i['user_id'],
                     i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone'])
-                    .set(1)
+                    i['OS-EXT-AZ:availability_zone']).set(1)
             instance_info_launch.labels(config['cloud'],
                     i['id'], i['name'], i['tenant_id'], i['user_id'],
                     i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone'])
-                    .set(dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
+                    i['OS-EXT-AZ:availability_zone']).set(
+                        dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
             instance_info_create.labels(config['cloud'],
                     i['id'], i['name'], i['tenant_id'], i['user_id']
                     , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone'])
-                    .set(dp.parse(i['created']).strftime('%s'))
+                    i['OS-EXT-AZ:availability_zone']).set(
+                        dp.parse(i['created']).strftime('%s'))
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -476,7 +476,7 @@ class Nova():
                             i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                             i['OS-EXT-SRV-ATTR:host'], flavorname,
                             i['OS-EXT-AZ:availability_zone']).set(
-                                dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s')*1000)
+                                dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s000'))
             except TypeError as te:
                 log.debug(te.message)
 
@@ -486,7 +486,7 @@ class Nova():
                             , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                             i['OS-EXT-SRV-ATTR:host'], flavorname,
                             i['OS-EXT-AZ:availability_zone']).set(
-                                dp.parse(i['created']).strftime('%s')*1000)
+                                dp.parse(i['created']).strftime('%s000'))
             except TypeError as te:
                 log.debug(te.message)
 

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -469,23 +469,24 @@ class Nova():
                     i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
                     i['OS-EXT-AZ:availability_zone']).set(1)
+
             try:
-            instance_info_launch.labels(config['cloud'],
-                    i['id'], i['name'], i['tenant_id'], i['user_id'],
-                    i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
-                    i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone']).set(
-                        dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
+                    instance_info_launch.labels(config['cloud'],
+                            i['id'], i['name'], i['tenant_id'], i['user_id'],
+                            i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
+                            i['OS-EXT-SRV-ATTR:host'], flavorname,
+                            i['OS-EXT-AZ:availability_zone']).set(
+                                dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
             except Error:
                 _
 
             try:
-            instance_info_create.labels(config['cloud'],
-                    i['id'], i['name'], i['tenant_id'], i['user_id']
-                    , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
-                    i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone']).set(
-                        dp.parse(i['created']).strftime('%s'))
+                    instance_info_create.labels(config['cloud'],
+                            i['id'], i['name'], i['tenant_id'], i['user_id']
+                            , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
+                            i['OS-EXT-SRV-ATTR:host'], flavorname,
+                            i['OS-EXT-AZ:availability_zone']).set(
+                                dp.parse(i['created']).strftime('%s'))
             except Error:
                 _
 

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -418,6 +418,12 @@ class Nova():
         instances = Gauge('nova_instances',
                           'Nova instances metrics',
                           ['cloud', 'tenant', 'instance_state'], registry=self.registry)
+        instance_info=Gauge('nova_instance_info',
+                            'Information about specific instances',
+                            ['cloud','id', 'name', 'tenant_id',
+                            'user_id', 'vm_state', 'power_state',
+                            'hypervisor_hostname', 'flavor', 'az']
+                            , registry=self.registry)
         res_ram = Gauge('nova_resources_ram_mbs',
                         'Nova RAM usage metric',
                         ['cloud', 'tenant'], registry=self.registry)
@@ -434,13 +440,23 @@ class Nova():
                 tenant = 'orphaned'
             instances.labels(config['cloud'], tenant, i['status']).inc()
 
-            if i['flavor']['id'] in self.flavor_map:
-                flavor = self.flavor_map[i['flavor']['id']]
+            f_id=i['flavor']['id']
+            flavorname=f_id
+            if f_id in self.flavor_map:
+                flavor = self.flavor_map[f_id]
                 res_ram.labels(config['cloud'], tenant).inc(flavor['ram'])
                 res_vcpus.labels(config['cloud'], tenant).inc(flavor['vcpus'])
                 res_disk.labels(config['cloud'], tenant).inc(flavor['disk'])
+                flavorname=flavor['name']
             else:
                 missing_flavors = True
+
+            instance_info.labels(config['cloud'],
+                    i['id'], i['name'], i['tenant_id'], i['user_id'],
+                    i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
+                    i['OS-EXT-SRV-ATTR:host'], flavorname,
+                    i['OS-EXT-AZ:availability_zone'])
+                    .set(1)
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -31,6 +31,7 @@ import urlparse
 from threading import Thread
 import pickle
 import requests
+import dateutil.parser as dp
 from time import sleep, time
 from neutronclient.v2_0 import client as neutron_client
 # from novaclient.v1_1 import client as nova_client
@@ -424,6 +425,18 @@ class Nova():
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
+        instance_info_launch=Gauge('nova_instance_launch_s',
+                            'Information about specific instances',
+                            ['cloud','id', 'name', 'tenant_id',
+                            'user_id', 'vm_state', 'power_state',
+                            'hypervisor_hostname', 'flavor', 'az']
+                            , registry=self.registry)
+        instance_info_create=Gauge('nova_instance_created_s',
+                            'Information about specific instances',
+                            ['cloud','id', 'name', 'tenant_id',
+                            'user_id', 'vm_state', 'power_state',
+                            'hypervisor_hostname', 'flavor', 'az']
+                            , registry=self.registry)
         res_ram = Gauge('nova_resources_ram_mbs',
                         'Nova RAM usage metric',
                         ['cloud', 'tenant'], registry=self.registry)
@@ -457,6 +470,18 @@ class Nova():
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
                     i['OS-EXT-AZ:availability_zone'])
                     .set(1)
+            instance_info_launch.labels(config['cloud'],
+                    i['id'], i['name'], i['tenant_id'], i['user_id'],
+                    i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
+                    i['OS-EXT-SRV-ATTR:host'], flavorname,
+                    i['OS-EXT-AZ:availability_zone'])
+                    .set(dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
+            instance_info_create.labels(config['cloud'],
+                    i['id'], i['name'], i['tenant_id'], i['user_id']
+                    , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
+                    i['OS-EXT-SRV-ATTR:host'], flavorname,
+                    i['OS-EXT-AZ:availability_zone'])
+                    .set(dp.parse(i['created']).strftime('%s'))
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -478,7 +478,7 @@ class Nova():
                             i['OS-EXT-AZ:availability_zone']).set(
                                 dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
             except Exception:
-                _
+                pass
 
             try:
                     instance_info_create.labels(config['cloud'],
@@ -488,7 +488,7 @@ class Nova():
                             i['OS-EXT-AZ:availability_zone']).set(
                                 dp.parse(i['created']).strftime('%s'))
             except Exception:
-                _
+                pass
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -425,26 +425,18 @@ class Nova():
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
-        try:
         instance_info_launch=Gauge('nova_instance_launch_s',
                             'Information about specific instances',
                             ['cloud','id', 'name', 'tenant_id',
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
-        except Error:
-            _
-
-        try:
         instance_info_create=Gauge('nova_instance_created_s',
                             'Information about specific instances',
                             ['cloud','id', 'name', 'tenant_id',
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
-        except Error:
-            _
-        
         res_ram = Gauge('nova_resources_ram_mbs',
                         'Nova RAM usage metric',
                         ['cloud', 'tenant'], registry=self.registry)
@@ -477,18 +469,25 @@ class Nova():
                     i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
                     i['OS-EXT-AZ:availability_zone']).set(1)
+            try:
             instance_info_launch.labels(config['cloud'],
                     i['id'], i['name'], i['tenant_id'], i['user_id'],
                     i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
                     i['OS-EXT-AZ:availability_zone']).set(
                         dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
+            except Error:
+                _
+
+            try:
             instance_info_create.labels(config['cloud'],
                     i['id'], i['name'], i['tenant_id'], i['user_id']
                     , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                     i['OS-EXT-SRV-ATTR:host'], flavorname,
                     i['OS-EXT-AZ:availability_zone']).set(
                         dp.parse(i['created']).strftime('%s'))
+            except Error:
+                _
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -425,18 +425,26 @@ class Nova():
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
+        try:
         instance_info_launch=Gauge('nova_instance_launch_s',
                             'Information about specific instances',
                             ['cloud','id', 'name', 'tenant_id',
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
+        except Error:
+            _
+
+        try:
         instance_info_create=Gauge('nova_instance_created_s',
                             'Information about specific instances',
                             ['cloud','id', 'name', 'tenant_id',
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
+        except Error:
+            _
+        
         res_ram = Gauge('nova_resources_ram_mbs',
                         'Nova RAM usage metric',
                         ['cloud', 'tenant'], registry=self.registry)

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -338,7 +338,7 @@ class Nova():
             self.prodstack = pickle.load(f)[0]
         self.hypervisors = self.prodstack['hypervisors']
         self.tenant_map = {t['id']: t['name'] for t in self.prodstack['tenants']}
-        self.flavor_map = {f['id']: {'ram': f['ram'], 'disk': f['disk'], 'vcpus': f['vcpus']}
+        self.flavor_map = {f['id']: {fk:f[fk] for fk in f.keys() }
                            for f in self.prodstack['flavors']}
         self.aggregate_map = {}
         self.services_map = {}

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -140,6 +140,7 @@ class DataGatherer(Thread):
         log.debug("Starting data gather thread")
         prodstack = {}
         while True:
+            log.debug('gathering run starts')
             start_time = time()
             try:
                 keystone, nova, neutron, cinder = get_clients()
@@ -195,6 +196,7 @@ class DataGatherer(Thread):
                 rename(self.cache_file + '.new', self.cache_file)
                 log.debug("Done dumping stats to {}".format(self.cache_file))
             self.duration = time() - start_time
+            log.debug('gathering run finished, sleeping now')
             sleep(self.refresh_interval)
 
     def get_stats(self):

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -477,7 +477,7 @@ class Nova():
                             i['OS-EXT-SRV-ATTR:host'], flavorname,
                             i['OS-EXT-AZ:availability_zone']).set(
                                 dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
-            except Error:
+            except Exception:
                 _
 
             try:
@@ -487,7 +487,7 @@ class Nova():
                             i['OS-EXT-SRV-ATTR:host'], flavorname,
                             i['OS-EXT-AZ:availability_zone']).set(
                                 dp.parse(i['created']).strftime('%s'))
-            except Error:
+            except Exception:
                 _
 
         # If flavors were deleted we can't reliably find out resouerce use

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -464,29 +464,53 @@ class Nova():
             else:
                 missing_flavors = True
 
-            instance_info.labels(config['cloud'],
-                    i['id'], i['name'], i['tenant_id'], i['user_id'],
-                    i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
-                    i['OS-EXT-SRV-ATTR:host'], flavorname,
-                    i['OS-EXT-AZ:availability_zone']).set(1)
+            instance_info.labels(
+                        config['cloud'],
+                        i['id'],
+                        i['name'],
+                        i['tenant_id'],
+                        i['user_id'],
+                        i['OS-EXT-STS:vm_state'],
+                        i['OS-EXT-STS:power_state'],
+                        i['OS-EXT-SRV-ATTR:host'],
+                        flavorname,
+                        i['OS-EXT-AZ:availability_zone']
+                    ).set(1)
 
             try:
-                    instance_info_launch.labels(config['cloud'],
-                            i['id'], i['name'], i['tenant_id'], i['user_id'],
-                            i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
-                            i['OS-EXT-SRV-ATTR:host'], flavorname,
-                            i['OS-EXT-AZ:availability_zone']).set(
-                                dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s000'))
+                instance_info_launch.labels(
+                            config['cloud'],
+                            i['id'], i['name'],
+                            i['tenant_id'],
+                            i['user_id'],
+                            i['OS-EXT-STS:vm_state'],
+                            i['OS-EXT-STS:power_state'],
+                            i['OS-EXT-SRV-ATTR:host'],
+                            flavorname,
+                            i['OS-EXT-AZ:availability_zone']
+                        ).set(
+                            dp.parse(i['OS-SRV-USG:launched_at']).
+                                strftime('%s000')
+                            )
             except TypeError as te:
                 log.debug(te.message)
 
             try:
-                    instance_info_create.labels(config['cloud'],
-                            i['id'], i['name'], i['tenant_id'], i['user_id']
-                            , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
-                            i['OS-EXT-SRV-ATTR:host'], flavorname,
-                            i['OS-EXT-AZ:availability_zone']).set(
-                                dp.parse(i['created']).strftime('%s000'))
+                    instance_info_create.labels(
+                                config['cloud'],
+                                i['id'],
+                                i['name'],
+                                i['tenant_id'],
+                                i['user_id'],
+                                i['OS-EXT-STS:vm_state'],
+                                i['OS-EXT-STS:power_state'],
+                                i['OS-EXT-SRV-ATTR:host'],
+                                flavorname,
+                                i['OS-EXT-AZ:availability_zone']
+                            ).set(
+                                dp.parse(i['created']).
+                                    strftime('%s000')
+                            )
             except TypeError as te:
                 log.debug(te.message)
 

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -425,13 +425,13 @@ class Nova():
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
-        instance_info_launch=Gauge('nova_instance_launch_s',
+        instance_info_launch=Gauge('nova_instance_launch_ms',
                             'Information about specific instances',
                             ['cloud','id', 'name', 'tenant_id',
                             'user_id', 'vm_state', 'power_state',
                             'hypervisor_hostname', 'flavor', 'az']
                             , registry=self.registry)
-        instance_info_create=Gauge('nova_instance_created_s',
+        instance_info_create=Gauge('nova_instance_created_ms',
                             'Information about specific instances',
                             ['cloud','id', 'name', 'tenant_id',
                             'user_id', 'vm_state', 'power_state',
@@ -476,7 +476,7 @@ class Nova():
                             i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                             i['OS-EXT-SRV-ATTR:host'], flavorname,
                             i['OS-EXT-AZ:availability_zone']).set(
-                                dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
+                                dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s')*1000)
             except TypeError as te:
                 log.debug(te.message)
 
@@ -486,7 +486,7 @@ class Nova():
                             , i['OS-EXT-STS:vm_state'], i['OS-EXT-STS:power_state'],
                             i['OS-EXT-SRV-ATTR:host'], flavorname,
                             i['OS-EXT-AZ:availability_zone']).set(
-                                dp.parse(i['created']).strftime('%s'))
+                                dp.parse(i['created']).strftime('%s')*1000)
             except TypeError as te:
                 log.debug(te.message)
 

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -477,8 +477,8 @@ class Nova():
                             i['OS-EXT-SRV-ATTR:host'], flavorname,
                             i['OS-EXT-AZ:availability_zone']).set(
                                 dp.parse(i['OS-SRV-USG:launched_at']).strftime('%s'))
-            except Exception:
-                pass
+            except TypeError as te:
+                log.debug(te.message)
 
             try:
                     instance_info_create.labels(config['cloud'],
@@ -487,8 +487,8 @@ class Nova():
                             i['OS-EXT-SRV-ATTR:host'], flavorname,
                             i['OS-EXT-AZ:availability_zone']).set(
                                 dp.parse(i['created']).strftime('%s'))
-            except Exception:
-                pass
+            except TypeError as te:
+                log.debug(te.message)
 
         # If flavors were deleted we can't reliably find out resouerce use
         if missing_flavors:

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -647,7 +647,7 @@ if __name__ == '__main__':
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('config_file', nargs='?',
                         help='Configuration file path',
-                        default='/etc/prometheus/prometheus-openstack-exporter.yaml',
+                        default='./prometheus-openstack-exporter.yaml',
                         type=argparse.FileType('r'))
     args = parser.parse_args()
     log.setLevel(logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
                       "python-novaclient==6.0.0",
                       "python-neutronclient<=6.1.0",
                       "python-cinderclient",
+                      "python-dateutil",
                       "netaddr"],
     long_description=read('README.md'),
     classifiers=[


### PR DESCRIPTION
This branch creates per-vm statistics, that can be used afterwards in prometheus to enrich the metrics with specific VM-Info

It also works around a possible headache with argparse, because the default for the config-file is set to /etc/* and argparse crashes hard (even when a different configfile is specified) when the default-file is not there. It makes IMHO totally sense to have at least a default, pointing to a location owned by root, because the exporter itself doesn't need root privileges on the system its running on.