### PR TITLE
Fix problem with return for / endpoint

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -1073,7 +1073,7 @@ class OpenstackExporterHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(
-                """<html>
+                b"""<html>
             <head><title>OpenStack Exporter</title></head>
             <body>
             <h1>OpenStack Exporter</h1>


### PR DESCRIPTION
/ endpoint was returning en empty body. Now returns the fixed string it is supposed to.