### PR TITLE
Use eventlet green thread instead of regular thread

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -35,7 +35,7 @@ from http.server import HTTPServer
 from os import environ as env
 from os import path, rename
 from socketserver import ForkingMixIn
-from threading import Thread
+from eventlet.green.threading import Thread
 from time import sleep, time
 
 from cinderclient.v3 import client as cinder_client

--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -35,10 +35,11 @@ from http.server import HTTPServer
 from os import environ as env
 from os import path, rename
 from socketserver import ForkingMixIn
-from eventlet.green.threading import Thread
 from time import sleep, time
 
 from cinderclient.v3 import client as cinder_client
+
+from eventlet.green.threading import Thread
 
 from netaddr import IPRange
 


### PR DESCRIPTION
This fixes the `greenlet.error: cannot switch to a different thread`
exception that leaves the server in deadlock