### PR TITLE
Disable setuptools package automatic discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     keywords=["prometheus", "openstack", "exporter"],
     url="https://github.com/CanonicalLtd/prometheus-openstack-exporter",
     scripts=["prometheus-openstack-exporter"],
+    packages=[],
     install_requires=[
         "prometheus_client",
         "python-keystoneclient<=3.10.0",


### PR DESCRIPTION
setuptools-61.0.0 introduced automatic discovery for packages if no `packages` or `py_modules` is explicitly specified. Package autodiscovery causes Debian builds to fail with:

     error: Multiple top-level packages discovered in a flat-layout: ['snap', 'debian'].

More information about this bug can be found in [Debian Bug #1021925](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1021925).  

This can be fixed by disabling package autodiscovery, as I believe that this software does not rely on that feature. More information in:

- https://setuptools.pypa.io/en/latest/history.html#v61-0-0
- https://github.com/pypa/setuptools/issues/3227
- https://github.com/pypa/setuptools/issues/3227#issuecomment-1081688343