### PR TITLE
Handle multiple aggregates properly

### DIFF
--- a/prometheus-openstack-exporter
+++ b/prometheus-openstack-exporter
@@ -494,7 +494,8 @@ class Nova:
             if s["binary"] == "nova-compute":
                 self.services_map[s["host"]] = s["status"]
         for agg in self.prodstack["aggregates"]:
-            self.aggregate_map.update({i: agg["name"] for i in agg["hosts"]})
+            self.aggregate_map.update({host + "_" + agg["name"]: agg["name"]
+                                      for host in agg["hosts"]})
 
     def _get_schedulable_instances(self, host):
         free_vcpus = (
@@ -616,29 +617,62 @@ class Nova:
             elif not isinstance(cpu_info, dict):
                 cpu_info = json.loads(cpu_info)
                 arch = cpu_info["arch"]
-            label_values = [
-                config["cloud"],
-                host,
-                self.aggregate_map.get(host, "unknown"),
-                self.services_map[host],
-                arch,
-            ]
-            # Disabled hypervisors return None below, convert to 0
-            vms.labels(*label_values).set(squashnone(h["running_vms"]))
-            vcpus_total.labels(*label_values).set(squashnone(h["vcpus"]))
-            vcpus_used.labels(*label_values).set(squashnone(h["vcpus_used"]))
-            mem_total.labels(*label_values).set(squashnone(h["memory_mb"]))
-            mem_used.labels(*label_values).set(squashnone(h["memory_mb_used"]))
-            disk_total.labels(*label_values).set(squashnone(h["local_gb"]))
-            disk_used.labels(*label_values).set(squashnone(h["local_gb_used"]))
 
-            if config.get("schedulable_instance_size", False):
-                schedulable_instances.labels(*label_values).set(
-                    self._get_schedulable_instances(h)
-                )
-                schedulable_instances_capacity.labels(*label_values).set(
-                    self._get_schedulable_instances_capacity(h)
-                )
+            at_least_one_aggregate = False
+            for agg in self.prodstack["aggregates"]:
+                agg_key = host + "_" + agg["name"]
+                if self.aggregate_map.get(agg_key) is None:
+                    continue
+                at_least_one_aggregate = True
+                label_values = [
+                    config["cloud"],
+                    host,
+                    self.aggregate_map[agg_key],
+                    self.services_map[host],
+                    arch,
+                ]
+                # Disabled hypervisors return None below, convert to 0
+                vms.labels(*label_values).set(squashnone(h["running_vms"]))
+                vcpus_total.labels(*label_values).set(squashnone(h["vcpus"]))
+                vcpus_used.labels(*label_values).set(squashnone(h["vcpus_used"]))
+                mem_total.labels(*label_values).set(squashnone(h["memory_mb"]))
+                mem_used.labels(*label_values).set(squashnone(h["memory_mb_used"]))
+                disk_total.labels(*label_values).set(squashnone(h["local_gb"]))
+                disk_used.labels(*label_values).set(squashnone(h["local_gb_used"]))
+
+                if config.get("schedulable_instance_size", False):
+                    schedulable_instances.labels(*label_values).set(
+                        self._get_schedulable_instances(h)
+                    )
+                    schedulable_instances_capacity.labels(*label_values).set(
+                        self._get_schedulable_instances_capacity(h)
+                    )
+
+            # host isn't part of any aggregate
+            if not at_least_one_aggregate:
+                label_values = [
+                    config["cloud"],
+                    host,
+                    "unknown",
+                    self.services_map[host],
+                    arch,
+                ]
+                # Disabled hypervisors return None below, convert to 0
+                vms.labels(*label_values).set(squashnone(h["running_vms"]))
+                vcpus_total.labels(*label_values).set(squashnone(h["vcpus"]))
+                vcpus_used.labels(*label_values).set(squashnone(h["vcpus_used"]))
+                mem_total.labels(*label_values).set(squashnone(h["memory_mb"]))
+                mem_used.labels(*label_values).set(squashnone(h["memory_mb_used"]))
+                disk_total.labels(*label_values).set(squashnone(h["local_gb"]))
+                disk_used.labels(*label_values).set(squashnone(h["local_gb_used"]))
+
+                if config.get("schedulable_instance_size", False):
+                    schedulable_instances.labels(*label_values).set(
+                        self._get_schedulable_instances(h)
+                    )
+                    schedulable_instances_capacity.labels(*label_values).set(
+                        self._get_schedulable_instances_capacity(h)
+                    )
 
     def gen_instance_stats(self):
         """Collect Nova instances statistics."""


### PR DESCRIPTION
Currently, if there are multiple aggregates present only the last one is displayed. So the current handling is broken.

This change lists them all so that it be grouped by hypervisors and/or individual aggregate type(s).

Fixes #38.


A different fix was proposed in https://github.com/canonical/prometheus-openstack-exporter/pull/57.
But it joins all the aggreates together and they can't be queried, if needed, by aggregate types once joined.

To contrast,

WIth #57, it'd looks like:
```
hypervisor_vcpus_total{aggregate="aggregate1,different_aggregate,another_one",arch="x86_64",cloud="mycloud",hypervisor_hostname="hypervisor1",nova_service_status="enabled"} 4.0
```

whereas I am proposing:
```
hypervisor_vcpus_total{aggregate="aggregate1",arch="x86_64",cloud="mycloud",hypervisor_hostname="hypervisor1",nova_service_status="enabled"} 4.0
hypervisor_vcpus_total{aggregate="different_aggregate",arch="x86_64",cloud="mycloud",hypervisor_hostname="hypervisor1",nova_service_status="enabled"} 4.0
hypervisor_vcpus_total{aggregate="another_one",arch="x86_64",cloud="mycloud",hypervisor_hostname="hypervisor1",nova_service_status="enabled"} 4.0
```

This is better for querying and also has been requested by a user.